### PR TITLE
bugfixes and misc cleanup.

### DIFF
--- a/agent/config.go
+++ b/agent/config.go
@@ -72,7 +72,7 @@ func NewConfigClient(template ConfigClient, options ...ConfigClientOption) Confi
 // DefaultConfigClient creates a default client configuration.
 func DefaultConfigClient(options ...ConfigClientOption) ConfigClient {
 	config := ConfigClient{
-		DeployTimeout: 20 * time.Minute,
+		DeployTimeout: bw.DefaultDeployTimeout,
 		Address:       systemx.HostnameOrLocalhost(),
 		DeployDataDir: bw.LocateDeployspace(bw.DefaultDeployspaceDir),
 	}
@@ -203,13 +203,12 @@ func BootstrapPeers(peers ...*Peer) peering.Static {
 // NewConfig creates a default configuration.
 func NewConfig(options ...ConfigOption) Config {
 	c := Config{
-		Name:                   systemx.HostnameOrLocalhost(),
-		Root:                   filepath.Join("/", "var", "cache", bw.DefaultDir),
-		KeepN:                  3,
-		SnapshotFrequency:      time.Hour,
-		MinimumNodes:           3,
-		BootstrapAttempts:      math.MaxInt32,
-		BootstrapDeployTimeout: 5 * time.Minute,
+		Name:              systemx.HostnameOrLocalhost(),
+		Root:              filepath.Join("/", "var", "cache", bw.DefaultDir),
+		KeepN:             3,
+		SnapshotFrequency: time.Hour,
+		MinimumNodes:      3,
+		BootstrapAttempts: math.MaxInt32,
 		DNSBind: dnsBind{
 			TTL:       60,
 			Frequency: time.Hour,
@@ -289,25 +288,24 @@ func ConfigOptionTorrent(p *net.TCPAddr) ConfigOption {
 
 // Config - configuration for agent processes.
 type Config struct {
-	Name                   string
-	Root                   string        // root directory to store long term data.
-	KeepN                  int           `yaml:"keepN"`
-	MinimumNodes           int           `yaml:"minimumNodes"`
-	BootstrapAttempts      int           `yaml:"bootstrapAttempts"`
-	SnapshotFrequency      time.Duration `yaml:"snapshotFrequency"`
-	BootstrapDeployTimeout time.Duration `yaml:"bootstrapDeployTimeout"`
-	RPCBind                *net.TCPAddr
-	RaftBind               *net.TCPAddr
-	SWIMBind               *net.TCPAddr
-	Secret                 string
-	ServerName             string
-	CA                     string
-	CredentialsMode        string `yaml:"credentialsSource"`
-	CredentialsDir         string `yaml:"credentialsDir"`
-	TorrentBind            *net.TCPAddr
-	DNSBind                dnsBind  `yaml:"dnsBind"`
-	DNSBootstrap           []string `yaml:"dnsBootstrap"`
-	AWSBootstrap           struct {
+	Name              string
+	Root              string        // root directory to store long term data.
+	KeepN             int           `yaml:"keepN"`
+	MinimumNodes      int           `yaml:"minimumNodes"`
+	BootstrapAttempts int           `yaml:"bootstrapAttempts"`
+	SnapshotFrequency time.Duration `yaml:"snapshotFrequency"`
+	RPCBind           *net.TCPAddr
+	RaftBind          *net.TCPAddr
+	SWIMBind          *net.TCPAddr
+	Secret            string
+	ServerName        string
+	CA                string
+	CredentialsMode   string `yaml:"credentialsSource"`
+	CredentialsDir    string `yaml:"credentialsDir"`
+	TorrentBind       *net.TCPAddr
+	DNSBind           dnsBind  `yaml:"dnsBind"`
+	DNSBootstrap      []string `yaml:"dnsBootstrap"`
+	AWSBootstrap      struct {
 		AutoscalingGroups []string `yaml:"autoscalingGroups"` // additional autoscaling groups to check for instances.
 	} `yaml:"awsBootstrap"`
 }

--- a/agent/dialers.go
+++ b/agent/dialers.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -103,6 +104,7 @@ type QuorumDialer struct {
 // Dial connects to a member of the quorum based on the cluster.
 func (t QuorumDialer) Dial(c cluster) (client Client, err error) {
 	for _, p := range c.Quorum() {
+		log.Println("dialing", spew.Sdump(p))
 		if client, err = t.dialer.Dial(p); err == nil {
 			break
 		}

--- a/agent/proxy/service.go
+++ b/agent/proxy/service.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"time"
 
 	"github.com/james-lawrence/bw"
 	"github.com/james-lawrence/bw/agent"
@@ -59,6 +60,7 @@ func (t Proxy) Deploy(dialer agent.Dialer, d agent.Dispatcher, dopts agent.Deplo
 		deployment.DeployOptionFilter(filter),
 		deployment.DeployOptionPartitioner(bw.ConstantPartitioner(dopts.Concurrency)),
 		deployment.DeployOptionIgnoreFailures(dopts.IgnoreFailures),
+		deployment.DeployOptionTimeout(time.Duration(dopts.Timeout)),
 	}
 
 	// At this point the deploy could take awhile, so we shunt it into the background.

--- a/agent/quorum/quorum.go
+++ b/agent/quorum/quorum.go
@@ -238,7 +238,7 @@ func (t *Quorum) Watch(out agent.Quorum_WatchServer) (err error) {
 	log.Println("watch invoked")
 	defer log.Println("watch completed")
 
-	switch s := p.State(); s {
+	switch state := p.State(); state {
 	case raft.Leader, raft.Follower, raft.Candidate:
 	default:
 		return errors.Errorf("watch must be run on a member of quorum: %s", s)

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Bootstrap", func() {
 			noopDeployer{err: nil},
 			deployment.CoordinatorOptionStorage(reg),
 		)
-		Expect(Bootstrap(context.Background(), p, mc, fd, dc)).ToNot(HaveOccurred())
+		Expect(Bootstrap(p, mc, fd, dc)).ToNot(HaveOccurred())
 	})
 
 	It("should fail when it fails to download the archive", func() {
@@ -156,7 +156,7 @@ var _ = Describe("Bootstrap", func() {
 			noopDeployer{err: nil},
 			deployment.CoordinatorOptionStorage(reg),
 		)
-		Expect(errors.Cause(Bootstrap(context.Background(), p, mc, fd, dc))).To(MatchError("download failed"))
+		Expect(errors.Cause(Bootstrap(p, mc, fd, dc))).To(MatchError("download failed"))
 	})
 
 	It("should fail when the deployment fails", func() {
@@ -201,6 +201,6 @@ var _ = Describe("Bootstrap", func() {
 			noopDeployer{err: errors.New("deployment failed")},
 			deployment.CoordinatorOptionStorage(reg),
 		)
-		Expect(errors.Cause(Bootstrap(context.Background(), p, mc, fd, dc))).To(MatchError("deployment failed"))
+		Expect(errors.Cause(Bootstrap(p, mc, fd, dc))).To(MatchError("deployment failed"))
 	})
 })

--- a/bw.go
+++ b/bw.go
@@ -26,6 +26,9 @@ const (
 	DirTorrents = "torrents"
 	// EnvFile environment file name.
 	EnvFile = "bw.env"
+
+	// DefaultDeployTimeout default timeout for a deployment.
+	DefaultDeployTimeout = time.Hour
 )
 
 // RandomID a random identifier.

--- a/commands/bw/agent.go
+++ b/commands/bw/agent.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"log"
 	"net"
@@ -195,10 +194,7 @@ func (t *agentCmd) bind(newCoordinator func(agentContext, storage.DownloadProtoc
 	t.runServer(server, rpcBind)
 	t.gracefulShutdown(c, rpcBind)
 
-	deadline, done := context.WithTimeout(context.Background(), t.config.BootstrapDeployTimeout)
-	defer done()
-
-	if !bootstrap.UntilSuccess(deadline, local.Peer, cx, dialer, coordinator) {
+	if !bootstrap.UntilSuccess(t.config.BootstrapAttempts, local.Peer, cx, dialer, coordinator) {
 		// if bootstrapping fails shutdown the process.
 		return errors.New("failed to bootstrap node shutting down")
 	}

--- a/deployment/coordinator.go
+++ b/deployment/coordinator.go
@@ -183,8 +183,6 @@ func (t *Coordinator) Deploy(opts agent.DeployOptions, archive agent.Archive) (d
 
 	dcopts := []DeployContextOption{
 		DeployContextOptionDispatcher(t.dispatcher),
-		DeployContextOptionDeadline(time.Duration(opts.Timeout)),
-		DeployContextOptionQuiet(opts.SilenceDeployLogs),
 	}
 
 	if dctx, err = NewDeployContext(t.deploysRoot, t.local, opts, archive, dcopts...); err != nil {

--- a/x/errorsx/errorsx.go
+++ b/x/errorsx/errorsx.go
@@ -1,5 +1,7 @@
 package errorsx
 
+import "time"
+
 // Compact returns the first error in the set, if any.
 func Compact(errs ...error) error {
 	for _, err := range errs {
@@ -16,4 +18,26 @@ type String string
 
 func (t String) Error() string {
 	return string(t)
+}
+
+// Timeout error.
+type Timeout interface {
+	Timedout() time.Duration
+}
+
+// Timedout represents a timeout.
+func Timedout(cause error, d time.Duration) error {
+	return timeout{
+		error: cause,
+		d:     d,
+	}
+}
+
+type timeout struct {
+	error
+	d time.Duration
+}
+
+func (t timeout) Timedout() time.Duration {
+	return t.d
 }

--- a/x/timex/timex.go
+++ b/x/timex/timex.go
@@ -1,6 +1,9 @@
 package timex
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // Every executes the provided function every duration.
 func Every(d time.Duration, do func()) {
@@ -15,4 +18,28 @@ func DurationOrDefault(a, b time.Duration) time.Duration {
 		return b
 	}
 	return a
+}
+
+// DurationMax select the maximum duration from the set.
+func DurationMax(ds ...time.Duration) (d time.Duration) {
+	for _, c := range ds {
+		if c > d {
+			d = c
+		}
+	}
+
+	return d
+}
+
+// DurationMin select the minimum duration from the set.
+func DurationMin(ds ...time.Duration) (d time.Duration) {
+	d = math.MaxInt64
+
+	for _, c := range ds {
+		if c < d {
+			d = c
+		}
+	}
+
+	return d
 }


### PR DESCRIPTION
- cleanup: remove bootstrap timeout configuration option
use bootstrap attempts to limit number of attempts and the timeout in
the deploy metadata to limit the time for the deploy itself.

- bugfix: do not attempt to add peers with empty server addresses to the
configuration.

- bugfix: cleanup edge cases around deploy timeouts, and make the default
timeout consistant throughout the codebase.